### PR TITLE
Fix version in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
         name: Action Test
         steps:
             # ...
-            - uses: testingbot/testingbot-tunnel-action@v1
+            - uses: testingbot/testingbot-tunnel-action@v1.1.0
               with:
                   key: ${{ secrets.TB_KEY }}
                   secret: ${{ secrets.TB_SECRET }}


### PR DESCRIPTION
The version to use is actually `v1.1.0`. Since the tag/version `v1` does not exist, the example will make a workflow run crash.

Just in case someone—just like me—simply copies over the example code from the GitHub Marketplace into their workflow files.